### PR TITLE
Add option to set FO as Pilot Flying

### DIFF
--- a/A330-main.xml
+++ b/A330-main.xml
@@ -1516,6 +1516,30 @@
 					</script>
 				</binding>
 			</key>
+			<key n="22">
+				<name>Ctrl-V</name>
+				<desc>Select Pilot Flying view (pilot or copilot)</desc>
+				<binding>
+					<condition>
+						<equals>
+							<property>/options/system/fo-view</property>
+							<value type="double">1</value>
+						</equals>
+					</condition>
+					<command>nasal</command>
+					<script>view.setViewByIndex(100);</script>
+				</binding>
+				<binding>
+					<condition>
+						<equals>
+							<property>/options/system/fo-view</property>
+							<value type="double">0</value>
+						</equals>
+					</condition>
+					<command>nasal</command>
+					<script>view.setViewByIndex(0);</script>
+				</binding>
+			</key>
 		</keyboard>
 	</input>
 

--- a/AircraftConfig/acconfig.nas
+++ b/AircraftConfig/acconfig.nas
@@ -182,6 +182,11 @@ setlistener("/sim/signals/fdm-initialized", func {
 	}
 	setprop("/systems/acconfig/options/revision", current_revision);
 	writeSettings();
+	
+	if (getprop("/options/system/fo-view") == 1) {
+		view.setViewByIndex(100);
+	}
+	
 	spinning.stop();
 });
 
@@ -220,6 +225,7 @@ var readSettings = func {
 	setprop("/controls/adirs/skip", getprop("/systems/acconfig/options/adirs-skip"));
 	setprop("/sim/model/autopush/route/show", getprop("/systems/acconfig/options/autopush/show-route"));
 	setprop("/sim/model/autopush/route/show-wingtip", getprop("/systems/acconfig/options/autopush/show-wingtip"));
+	setprop("/options/system/fo-view", getprop("/systems/acconfig/options/fo-view"));
 }
 
 var writeSettings = func {
@@ -227,6 +233,7 @@ var writeSettings = func {
 	setprop("/systems/acconfig/options/adirs-skip", getprop("/controls/adirs/skip"));
 	setprop("/systems/acconfig/options/autopush/show-route", getprop("/sim/model/autopush/route/show"));
 	setprop("/systems/acconfig/options/autopush/show-wingtip", getprop("/sim/model/autopush/route/show-wingtip"));
+	setprop("/systems/acconfig/options/fo-view", getprop("/options/system/fo-view"));
 	io.write_properties(getprop("/sim/fg-home") ~ "/Export/Airbus_A330-config.xml", "/systems/acconfig/options");
 }
 

--- a/AircraftConfig/help.xml
+++ b/AircraftConfig/help.xml
@@ -9,25 +9,25 @@
 	<name>aircraft-config-help</name>
 	<layout>vbox</layout>
 
-    <group>
-        <layout>hbox</layout>
-        <text>
-            <halign>left</halign>
-            <label>Help</label>
-        </text>
-        <button>
-            <halign>right</halign>
-            <pref-width>20</pref-width>
-            <pref-height>20</pref-height>
-            <legend>X</legend>
-            <key>Esc</key>
-            <binding>
-                <command>dialog-close</command>
-            </binding>
-        </button>
-    </group>
+	<group>
+		<layout>hbox</layout>
+		<text>
+			<halign>left</halign>
+			<label>Help</label>
+		</text>
+		<button>
+			<halign>right</halign>
+			<pref-width>20</pref-width>
+			<pref-height>20</pref-height>
+			<legend>X</legend>
+			<key>Esc</key>
+			<binding>
+				<command>dialog-close</command>
+			</binding>
+		</button>
+	</group>
 	
-    <hrule/>
+	<hrule/>
 	
 		<group>
 			<layout>vbox</layout>
@@ -122,6 +122,10 @@
 			<text>
 				<halign>left</halign>
 				<label>SHIFT + F - Set CL Thrust</label>
+			</text>
+			<text>
+				<halign>left</halign>
+				<label>CTRL + V - Select Pilot Flying view (See Aircraft Configuration dialog)</label>
 			</text>
 			
 		</group>

--- a/AircraftConfig/main.xml
+++ b/AircraftConfig/main.xml
@@ -446,6 +446,26 @@
 				<live>true</live>
 			</checkbox>
 			
+			<checkbox>
+				<label>First Officer is the Pilot Flying</label>
+				<halign>left</halign>
+				<property>/options/system/fo-view</property>
+				<binding>
+					<command>property-toggle</command>
+					<property>/options/system/fo-view</property>
+				</binding>
+				<binding>
+					<command>dialog-apply</command>
+				</binding>
+				<binding>
+					<command>nasal</command>
+					<script>
+					acconfig.writeSettings();
+					</script>
+				</binding>
+				<live>true</live>
+			</checkbox>
+			
 			<group>
 				<layout>hbox</layout>
 			


### PR DESCRIPTION
I added an option in the configuration dialog to set the First Officer as Pilot Flying. With `Ctrl + V` the Pilot Flying view is selected.
This feature was originally requested for the A320 but I think its also a nice feature for the A330. Or am I the only person who likes to fly as a First Officer? :wink: 

Regards,
Lukas